### PR TITLE
feat: [PIDM-504] update deploy config and strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ package-lock.json
 /helm/charts/*
 **/.terraform/
 **/*.hcl
+helm/Chart.lock

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.40.0
 appVersion: 2.0.6
 dependencies:
   - name: microservice-chart
-    version: 7.5.0
+    version: 8.0.2
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,6 +2,11 @@ microservice-chart:
   namespace: "gps"
   nameOverride: ""
   fullnameOverride: "gpd-payments-pull"
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments-pull
     tag: "2.0.6"
@@ -20,6 +25,9 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
+  deployment:
+    create: true
+    replicas: 1 # (default) same as HPA minReplica
   ports:
     - 8080 #http
   service:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,11 +2,6 @@ microservice-chart:
   namespace: "gps"
   nameOverride: ""
   fullnameOverride: "gpd-payments-pull"
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments-pull
     tag: "2.0.6"
@@ -28,6 +23,11 @@ microservice-chart:
   deployment:
     create: true
     replicas: 1 # (default) same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   ports:
     - 8080 #http
   service:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,6 +2,11 @@ microservice-chart:
   namespace: "gps"
   nameOverride: ""
   fullnameOverride: "gpd-payments-pull"
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments-pull
     tag: "2.0.6"
@@ -20,6 +25,9 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
+  deployment:
+    create: true
+    replicas: 3 # same as HPA minReplica
   ports:
     - 8080 #http
   service:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,11 +2,6 @@ microservice-chart:
   namespace: "gps"
   nameOverride: ""
   fullnameOverride: "gpd-payments-pull"
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments-pull
     tag: "2.0.6"
@@ -28,6 +23,11 @@ microservice-chart:
   deployment:
     create: true
     replicas: 3 # same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   ports:
     - 8080 #http
   service:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,6 +2,11 @@ microservice-chart:
   namespace: "gps"
   nameOverride: ""
   fullnameOverride: "gpd-payments-pull"
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments-pull
     tag: "2.0.6"
@@ -20,6 +25,9 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
+  deployment:
+    create: true
+    replicas: 1 # (default) same as HPA minReplica
   ports:
     - 8080 #http
   service:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,11 +2,6 @@ microservice-chart:
   namespace: "gps"
   nameOverride: ""
   fullnameOverride: "gpd-payments-pull"
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments-pull
     tag: "2.0.6"
@@ -28,6 +23,11 @@ microservice-chart:
   deployment:
     create: true
     replicas: 1 # (default) same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   ports:
     - 8080 #http
   service:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- upgraded helm chart to v8.0.2
- added rolling update strategy (maxUnavailable, maxSurge)
- overridden deployment replicas to match HPA minReplica config

NOTE: upgraded in

- DEV -> OK
- UAT -> TODO
- PROD -> TODO

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This upgrade was required to address an issue with the rollout strategy and the autoscaler behaviour, where the pods would scale down to 1 during deploy instead of keeping the same number of pods and doing +1 -1 to avoid traffic congestion. Also replicas are set to match the autoscaling config during deploy, to avoid starting the service with 1 pod when there is relevant traffic on the service.
This also ensures zero-downtime deployments by keeping all existing pods running until new versions are healthy and ready, then replacing them one at a time.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

```
❯ helm upgrade --namespace gps \
    --install --values ./helm/values-dev.yaml \
    --set microservice-chart.azure.workloadIdentityClientId=8a7f62fa-6865-4fc0-a774-337e3982d20f \
    --set microservice-chart.podAnnotations.force-rollout="rollout-$(date +%s)" \
    --wait --timeout 15m0s \
    gpd-payments-pull ./helm
coalesce.go:298: warning: cannot overwrite table with non table for gpd-payments-pull.microservice-chart.envFieldRef (map[])
Release "gpd-payments-pull" has been upgraded. Happy Helming!
NAME: gpd-payments-pull
LAST DEPLOYED: Tue Oct 14 11:30:26 2025
NAMESPACE: gps
STATUS: deployed
REVISION: 9
TEST SUITE: None
```

```
❯ kubectl get scaledobject gpd-payments-pull -n gps -o jsonpath='{.metadata.labels.helm\.sh/blueprint-version}'
8.0.2%
```

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
